### PR TITLE
修复负数被判断不是数字的问题

### DIFF
--- a/autopoi/src/main/java/org/jeecgframework/poi/util/ExcelUtil.java
+++ b/autopoi/src/main/java/org/jeecgframework/poi/util/ExcelUtil.java
@@ -267,7 +267,7 @@ public class ExcelUtil {
      * @return
      */
     private static boolean isNumberString(String str){
-        String regex = "^[0-9]+\\.0+$";
+        String regex = "^[-0-9]+\\.0+$";
         Pattern pattern = Pattern.compile(regex);
         Matcher m = pattern.matcher(str);
         if (m.find()) {


### PR DESCRIPTION
修复 例如：-100.0 被判断不是数字的问题，导致ExcelUtil.remove0Suffix 转换失效报错