### PR TITLE
fix: Jeecg Boot issues #8230 - autopoi使用模板导出时,如果传入的map中存在值为null时会导致异常…

### DIFF
--- a/autopoi/src/main/java/org/jeecgframework/poi/util/PoiPublicUtil.java
+++ b/autopoi/src/main/java/org/jeecgframework/poi/util/PoiPublicUtil.java
@@ -671,7 +671,9 @@ public final class PoiPublicUtil {
 			return getValueDoWhile(object, paramsArr, 0);
 		}
 		if (object instanceof Map) {
-			return ((Map) object).get(params);
+			return Optional.of((Map) object)
+					.map(map -> map.get(params))
+					.orElse("");
 		}
 		return getMethod(params, object.getClass()).invoke(object, new Object[] {});
 	}


### PR DESCRIPTION
https://github.com/jeecgboot/JeecgBoot/issues/8230

修复 JeecgBoot 项目，提出的 8230 问题