### PR TITLE
fix issue 导入excel时，标题区域的空行会导致下方列表数据被吞  jeecgboot/jimureport#3943

### DIFF
--- a/autopoi/src/main/java/org/jeecgframework/poi/excel/imports/ExcelImportServer.java
+++ b/autopoi/src/main/java/org/jeecgframework/poi/excel/imports/ExcelImportServer.java
@@ -192,9 +192,12 @@ public class ExcelImportServer extends ImportBaseService {
         Integer minColumnIndex = Collections.min(columnIndexSet);
 		Row row = null;
 		//跳过表头和标题行
-		for (int j = 0; j < params.getTitleRows() + params.getHeadRows(); j++) {
-			row = rows.next();
-		}
+		//update-begin---author:chenrui ---date:20250715  for：[issues/3943]导入excel时，标题区域的空行会导致下方列表数据被吞------------
+		int skipRowNum = params.getTitleRows() + params.getHeadRows();
+        do {
+            row = rows.next();
+        } while (row.getRowNum() != skipRowNum - 1);
+		//update-end---author:chenrui ---date:20250715  for：[issues/3943]导入excel时，标题区域的空行会导致下方列表数据被吞------------
 		Object object = null;
 		String picId;
 		while (rows.hasNext() && (row == null || sheet.getLastRowNum() - row.getRowNum() > params.getLastOfInvalidRow())) {

--- a/docs/修改日志.log
+++ b/docs/修改日志.log
@@ -118,3 +118,7 @@ src/main/java/org/jeecgframework/poi/excel/export/base/ExcelExportBase.java
 ---author:liusq---date:2024/6/24-----for:[issues/8489] autopoi模板导出虽然公式单元格没问题了，但是正常的字符串单元格出错了 #8489--
 autopoi\src\main\java\org\jeecgframework\poi\util\PoiExcelTempUtil.java
 ---author:liusq---date:2024/6/24-----for:[issues/8489] autopoi模板导出虽然公式单元格没问题了，但是正常的字符串单元格出错了 #8489--
+
+---author:chenrui---date:2025/7/16-----for:[issues/3943]导入excel时，标题区域的空行会导致下方列表数据被吞---
+src/main/java/org/jeecgframework/poi/excel/imports/ExcelImportServer.java
+---author:chenrui---date:2025/7/16-----for:[issues/3943]导入excel时，标题区域的空行会导致下方列表数据被吞---


### PR DESCRIPTION
for jeecgboot/jimureport#3943 导入excel时，标题区域的空行会导致下方列表数据被吞