### PR TITLE
修复TWO_DECIMAL判断逻辑bug

### DIFF
--- a/autopoi/src/main/java/org/jeecgframework/poi/util/PoiFunctionUtil.java
+++ b/autopoi/src/main/java/org/jeecgframework/poi/util/PoiFunctionUtil.java
@@ -84,7 +84,7 @@ public final class PoiFunctionUtil {
 		}
 		double number = Double.valueOf(obj.toString());
 		DecimalFormat decimalFormat = null;
-		if (TWO_DECIMAL.equals(format)) {
+		if (TWO_DECIMAL_STR.equals(format)) {
 			decimalFormat = TWO_DECIMAL;
 		} else if (THREE_DECIMAL_STR.equals(format)) {
 			decimalFormat = THREE_DECIMAL;


### PR DESCRIPTION
由于format 为String类型，此处应当使用 TWO_DECIMAL_STR 字符串做逻辑判断而不是 TWO_DECIMAL 对象。